### PR TITLE
Use 64 bit int on all platforms

### DIFF
--- a/skfmm/base_marcher.cpp
+++ b/skfmm/base_marcher.cpp
@@ -12,7 +12,7 @@ extern "C" {
 
 
 baseMarcher::baseMarcher(
-  double *phi,      double *dx,   long *flag,
+  double *phi,      double *dx,   long long *flag,
   double *distance, int     ndim, int *shape,
   bool self_test,   int order,    double narrow,
   int periodic)

--- a/skfmm/base_marcher.h
+++ b/skfmm/base_marcher.h
@@ -18,7 +18,7 @@ extern "C" {
 class baseMarcher
 {
 public:
-  baseMarcher(double *phi,      double *dx,  long *flag,
+  baseMarcher(double *phi,      double *dx,  long long *flag,
               double *distance, int ndim,    int *shape,
               bool self_test,   int order,   double narrow,
               int periodic);
@@ -94,7 +94,7 @@ protected:
   double          * distance_; // return value modified in place
   double          * phi_;
   double          * dx_;
-  long            * flag_;
+  long long       * flag_;
   int               error_;
   int               dim_;            // number of dimensions
   int               size_;           // flat size

--- a/skfmm/distance_marcher.h
+++ b/skfmm/distance_marcher.h
@@ -5,7 +5,7 @@
 class distanceMarcher : public baseMarcher
 {
 public:
-  distanceMarcher(double *phi,      double *dx, long *flag,
+  distanceMarcher(double *phi,      double *dx, long long *flag,
                   double *distance, int ndim,   int *shape,
                   bool self_test,   int order,  double narrow,
                   int periodic):

--- a/skfmm/extension_velocity_marcher.h
+++ b/skfmm/extension_velocity_marcher.h
@@ -5,9 +5,9 @@
 class extensionVelocityMarcher : public distanceMarcher
 {
 public:
-  extensionVelocityMarcher(double *phi,      double *dx,    long *flag,
+  extensionVelocityMarcher(double *phi,      double *dx,    long long *flag,
                            double *distance, int     ndim,  int *shape,
-                           bool self_test,   int order,     long *ext_mask,
+                           bool self_test,   int order,     long long *ext_mask,
                            double *speed,
                            double *f_ext,    double narrow, int periodic) :
     distanceMarcher(phi, dx, flag, distance, ndim, shape, self_test,
@@ -23,5 +23,5 @@ protected:
 private:
   double *speed_;
   double *f_ext_;
-  long *ext_mask_;
+  long long *ext_mask_;
 };

--- a/skfmm/fmm.cpp
+++ b/skfmm/fmm.cpp
@@ -240,9 +240,9 @@ static PyObject *distance_method(PyObject *self, PyObject *args)
   // create a level set object to do the calculation
   double * local_phi        = (double *) PyArray_DATA(phi);
   double * local_dx         = (double *) PyArray_DATA(dx);
-  long   * local_flag       = (long *)   PyArray_DATA(flag);
-  long    * local_ext_mask   = 0;
-  if (ext_mask) local_ext_mask = (long *) PyArray_DATA(ext_mask);
+  long long   * local_flag       = (long long *)   PyArray_DATA(flag);
+  long long   * local_ext_mask   = 0;
+  if (ext_mask) local_ext_mask = (long long *) PyArray_DATA(ext_mask);
   double * local_speed      = 0;
   if (speed) local_speed    = (double *) PyArray_DATA(speed);
   double * local_distance   = (double *) PyArray_DATA(distance);

--- a/skfmm/travel_time_marcher.h
+++ b/skfmm/travel_time_marcher.h
@@ -7,7 +7,7 @@ class heap;
 class travelTimeMarcher : public distanceMarcher
 {
 public:
-  travelTimeMarcher(double *phi,      double *dx, long *flag,
+  travelTimeMarcher(double *phi,      double *dx, long long *flag,
                     double *distance, int ndim,   int *shape,
                     bool self_test,   int order,
                     double *speed,    double narrow,


### PR DESCRIPTION
Remaining instances of "long" -> "long long" conversion. 
Fix for Numpy 2.0 incompatibility on Windows build.